### PR TITLE
Fixed problem with remote interfaces

### DIFF
--- a/jee7-ejb-starter/src/main/java/com/realdolmen/candyshop/services/CandyService.java
+++ b/jee7-ejb-starter/src/main/java/com/realdolmen/candyshop/services/CandyService.java
@@ -19,7 +19,6 @@ public class CandyService implements CandyServiceInterface {
     @Inject
     PersonService personService;
 
-    @Override
     public CandyRepository getCandyRepository() {
         return candyRepository;
     }

--- a/jee7-ejb-starter/src/main/java/com/realdolmen/candyshop/services/CandyServiceInterface.java
+++ b/jee7-ejb-starter/src/main/java/com/realdolmen/candyshop/services/CandyServiceInterface.java
@@ -9,8 +9,6 @@ import java.util.List;
 
 @Remote
 public interface CandyServiceInterface {
-    CandyRepository getCandyRepository();
-
     List<Candy> findAllCandy();
 
     List<Candy> findCandyByColor(CandyColor candyColor);

--- a/jee7-ejb-starter/src/test/java/com/realdolmen/candyshop/integration/CandyServiceIntegrationTest.java
+++ b/jee7-ejb-starter/src/test/java/com/realdolmen/candyshop/integration/CandyServiceIntegrationTest.java
@@ -1,30 +1,44 @@
 package com.realdolmen.candyshop.integration;
 
 import com.realdolmen.candyshop.AbstractRemoteIntegrationTest;
+import com.realdolmen.candyshop.domain.Candy;
+import com.realdolmen.candyshop.domain.CandyColor;
 import com.realdolmen.candyshop.services.CandyService;
 import com.realdolmen.candyshop.services.CandyServiceInterface;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import java.util.List;
 
 public class CandyServiceIntegrationTest extends AbstractRemoteIntegrationTest
 {
+    private static final int TOTAL_CANDY_IN_TEST_DATASET = 6;
+
     CandyServiceInterface candyService;
 
     @Before
     public void getCandyRepoTest() throws Exception {
         candyService = (CandyServiceInterface) context.lookup("jee7-ejb-starter/CandyService!com.realdolmen.candyshop.services.CandyServiceInterface");
-
+        assertNotNull(candyService);
     }
 
     @Test
-    public void candyServiceHasRepo()
-    {
-        assertNotNull(candyService);
-        assertNotNull(candyService.getCandyRepository());
+    public void candyServiceShouldReturnAllCandyWhenAskedToDoSo() throws Exception {
+        List<Candy> candy = candyService.findAllCandy();
+        assertEquals(TOTAL_CANDY_IN_TEST_DATASET, candy.size());
+    }
+
+    @Test
+    public void candyServiceShouldReturnsAllCandyByColor() throws Exception {
+        CandyColor colorToQuery = CandyColor.RED;
+        List<Candy> candy = candyService.findCandyByColor(colorToQuery);
+        assertEquals(1, candy.size());
+        assertEquals(colorToQuery, candy.get(0).getColor());
     }
 }


### PR DESCRIPTION
A couple of things to say:

* Don't include getters for internal dependencies to your java interfaces. They are for internal dependency injection and should not be part of your public interfaces (you don't want anyone to use it to screw up the inner dependency anyway)

* The actual problem caused was related to this, since you were trying to retrieve a reference through a remote interface to a dependency that does not have a remote interface itself. This caused the proxy error

* To test these remote services, try to aim for an interface perspective. That is: check if the interface can be consumed the way it should be (e.g. test that `findAllCandy()` actually returns candy. This indirectly proves that the inner structure of the service is also good. Don't test if the inner structure is hooked up correctly directly (e.g. if `getRepostory()` contains something), as this focuses too much on implementation detail. It would cause the test to become brittle (e.g. breaks easily upon any and minor changes in implementation of the class under test. Interesting information about the subject (in a more neural way): https://martinfowler.com/articles/mocksArentStubs.html